### PR TITLE
refactor(projects): rename params variable to avoid conflict

### DIFF
--- a/src/app/projects/edit/[id]/page.jsx
+++ b/src/app/projects/edit/[id]/page.jsx
@@ -22,7 +22,8 @@ import { mockProjects } from "@/components/dashboard/project-management" // We'l
 
 export default function EditProjectPage() {
   const router = useRouter()
-  const params = useParams()
+  // Rename this variable to avoid the conflict
+  const urlParams = useParams()
   const [project, setProject] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [newTag, setNewTag] = useState("")


### PR DESCRIPTION
The `params` variable was renamed to `urlParams` to avoid a naming conflict with the `params` prop passed to the component. This improves code clarity and prevents potential bugs.